### PR TITLE
Update FixSecureBootBulk.ps1

### DIFF
--- a/FixSecureBootBulk.ps1
+++ b/FixSecureBootBulk.ps1
@@ -354,7 +354,7 @@ function Get-VMDatastoreContext {
     $vmDir   = $vmxPath -replace '^\[.+?\] (.+)/[^/]+$', '$1'
     $ds      = Get-Datastore -Name $dsName -ErrorAction Stop
 
-    $datacenter      = Get-Datacenter | Select-Object -First 1
+    $datacenter      = Get-Datacenter -VM $VMObj
     $datacenterView  = $datacenter | Get-View
     $serviceInstance = Get-View ServiceInstance
 
@@ -1723,3 +1723,4 @@ if ($noteVMs) {
         Write-Host "    $($n.Notes)"
     }
 }
+


### PR DESCRIPTION
Fix for vCenter Datacenter selection (now based on the processed Vm).

I tested the script several times and repeatedly encountered problems when renaming the *.nvram files. As soon as you use multiple “datacenters” in vCenter, you have to select the "datacenter" based on the VM so that the correct “VMDatastoreContext” is assigned.

regards
smiszewski